### PR TITLE
Fix compile error, changes in GeglAudio

### DIFF
--- a/iconographer.c
+++ b/iconographer.c
@@ -496,12 +496,12 @@ main (gint    argc,
               float right_sum = 0;
               for (i = 0; i < audio->samples; i++)
               {
-                left_sum += fabs (audio->left[i]);
-                right_sum += fabs (audio->right[i]);
-                if (fabs (audio->left[i]) > left_max)
-                  left_max = fabs (audio->left[i]);
-                if (fabs (audio->right[i]) > right_max)
-                  right_max = fabs (audio->right[i]);
+                left_sum += fabs (audio->data[0][i]);
+                right_sum += fabs (audio->data[1][i]);
+                if (fabs (audio->data[0][i]) > left_max)
+                  left_max = fabs (audio->data[0][i]);
+                if (fabs (audio->data[1][i]) > right_max)
+                  right_max = fabs (audio->data[1][i]);
               }
               left_sum /= audio->samples;
               right_sum /= audio->samples;


### PR DESCRIPTION
->left has become ->data[0] and ->right become ->data[1]

gnome/gegl@7d4c0de65e
https://git.gnome.org/browse/gegl/commit/?h=video-rejuvenation&id=7d4c0de65e706ae5afb4d1994f05e1643de99b5a
